### PR TITLE
 make build script work with custom superset-ui

### DIFF
--- a/packages/superset-ui-chart-controls/package.json
+++ b/packages/superset-ui-chart-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/chart-controls",
-  "version": "0.18.0",
+  "version": "0.18.1000",
   "description": "Superset UI control-utils",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "@react-icons/all-files": "^4.1.0",
-    "@superset-ui/core": "0.18.0",
+    "@superset-ui/core": "0.18.1000",
     "lodash": "^4.17.15",
     "prop-types": "^15.7.2"
   },

--- a/packages/superset-ui-core/package.json
+++ b/packages/superset-ui-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/core",
-  "version": "0.18.0",
+  "version": "0.18.1000",
   "description": "Superset UI core",
   "sideEffects": false,
   "main": "lib/index.js",

--- a/plugins/legacy-preset-chart-nvd3/package.json
+++ b/plugins/legacy-preset-chart-nvd3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/legacy-preset-chart-nvd3",
-  "version": "0.18.0",
+  "version": "0.18.1000",
   "description": "Superset Legacy Chart - NVD3",
   "sideEffects": [
     "*.css"
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "@data-ui/xy-chart": "^0.0.84",
-    "@superset-ui/chart-controls": "0.18.0",
-    "@superset-ui/core": "0.18.0",
+    "@superset-ui/chart-controls": "0.18.1000",
+    "@superset-ui/core": "0.18.1000",
     "d3": "^3.5.17",
     "d3-tip": "^0.9.1",
     "dompurify": "^2.0.6",

--- a/plugins/plugin-chart-echarts/package.json
+++ b/plugins/plugin-chart-echarts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@superset-ui/plugin-chart-echarts",
-  "version": "0.18.1",
+  "version": "0.18.1000",
   "description": "Superset Chart - Echarts",
   "sideEffects": false,
   "main": "lib/index.js",
@@ -26,8 +26,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@superset-ui/chart-controls": "0.18.0",
-    "@superset-ui/core": "0.18.0",
+    "@superset-ui/chart-controls": "0.18.1000",
+    "@superset-ui/core": "0.18.1000",
     "@types/mathjs": "^6.0.7",
     "d3-array": "^1.2.0",
     "echarts": "^5.1.2",


### PR DESCRIPTION
All that's happening here is that I'm bumping the version number to something silly so that it won't conflict with real versions of superset-ui.  Those versions will get used in the customized askstylo/superset.