### PR TITLE
Drilldown

### DIFF
--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -60,7 +60,10 @@ export default class DistBarChartPlugin extends ChartPlugin {
       transformProps: chartProps => {
         const drillDown = chartProps.formData.drillDown;
         if (drillDown) {
-          chartProps.ownState = {...(chartProps.ownState && { drilldown: DrillDown.fromHierarchy(chartProps.formData.groupby) })};
+          chartProps.ownState = {
+            ...(!chartProps.ownState.drilldown && { drilldown: DrillDown.fromHierarchy(chartProps.formData.groupby) }),
+            ...chartProps.ownState
+          };
           chartProps.formData.groupby = [DrillDown.getColumn(chartProps.ownState.drilldown, [])];
         }
         return transformProps(chartProps);

--- a/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
+++ b/plugins/legacy-preset-chart-nvd3/src/DistBar/index.js
@@ -58,10 +58,10 @@ export default class DistBarChartPlugin extends ChartPlugin {
       loadChart: () => import('../ReactNVD3'),
       metadata,
       transformProps: chartProps => {
-        const { formData, ownState } = chartProps;
-        const { drillDown } = formData;
-        if (drillDown && ownState?.drilldown) {
-          chartProps.formData.groupby = [DrillDown.getColumn(ownState.drilldown, [])];
+        const drillDown = chartProps.formData.drillDown;
+        if (drillDown) {
+          chartProps.ownState = {...(chartProps.ownState && { drilldown: DrillDown.fromHierarchy(chartProps.formData.groupby) })};
+          chartProps.formData.groupby = [DrillDown.getColumn(chartProps.ownState.drilldown, [])];
         }
         return transformProps(chartProps);
       },


### PR DESCRIPTION
🐛 Bug Fix
one effect of using the reset button on the superset dashboards is that it erases the chart's "ownState," which is used by the drilldown to persist the filters, etc.  this change ensures that ownState is recreated in case it is cleared by the dashboard reset button.