### PR TITLE
fix for pie chart losing drilldown state when filters cleared

### DIFF
--- a/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
+++ b/plugins/plugin-chart-echarts/src/Pie/transformProps.ts
@@ -83,7 +83,7 @@ export function formatPieLabel({
 }
 
 export default function transformProps(chartProps: EchartsPieChartProps): PieChartTransformedProps {
-  const { formData, height, hooks, filterState, queriesData, width, ownState } = chartProps;
+  const { formData, height, hooks, filterState, queriesData, width } = chartProps;
   const { data = [] } = queriesData[0];
   const coltypeMapping = getColtypesMapping(queriesData[0]);
 
@@ -108,6 +108,14 @@ export default function transformProps(chartProps: EchartsPieChartProps): PieCha
     emitFilter,
     drillDown,
   }: EchartsPieFormData = { ...DEFAULT_LEGEND_FORM_DATA, ...DEFAULT_PIE_FORM_DATA, ...formData };
+
+  const ownState = {
+    ...(chartProps.ownState.drilldown
+      ? {}
+      : { drilldown: DrillDown.fromHierarchy(formData.groupby) }),
+    ...chartProps.ownState,
+  };
+
   const metricLabel = getMetricLabel(metric);
   const minShowLabelAngle = (showLabelsThreshold || 0) * 3.6;
   const groupby =


### PR DESCRIPTION
🐛 Bug Fix
similar to a small-scale change to bar charts that restores drilldown state when filters cleared either by tab navigation or by manually hitting the clear filters control in superset.
